### PR TITLE
Adds administrative region terms

### DIFF
--- a/src/ontology/OntoFox-input/input_ENVO.txt
+++ b/src/ontology/OntoFox-input/input_ENVO.txt
@@ -8,6 +8,11 @@ http://purl.obolibrary.org/obo/eupath/dev/import_ENVO.owl
 ENVO
 
 [Low level source term URIs]
+http://purl.obolibrary.org/obo/ENVO_00000005 #first-order administrative region
+http://purl.obolibrary.org/obo/ENVO_00000006 #second-order administrative region
+http://purl.obolibrary.org/obo/ENVO_00000007 #third-order administrative region
+http://purl.obolibrary.org/obo/ENVO_00000008 #fourth-order administrative region
+http://purl.obolibrary.org/obo/ENVO_00000009 #national geopolitical entity
 http://purl.obolibrary.org/obo/ENVO_00000014 #canal
 http://purl.obolibrary.org/obo/ENVO_00000016 #sea
 http://purl.obolibrary.org/obo/ENVO_00000020 #lake

--- a/src/ontology/OntoFox-input/input_ENVO.txt
+++ b/src/ontology/OntoFox-input/input_ENVO.txt
@@ -208,6 +208,8 @@ http://purl.obolibrary.org/obo/ENVO_00000035 #marsh
 subClassOf http://purl.obolibrary.org/obo/ENVO_01001209 #wetland
 http://purl.obolibrary.org/obo/ENVO_01000573 #battery-powered electric lamp
 subClassOf http://purl.obolibrary.org/obo/ENVO_01000572 #electric lamp
+http://purl.obolibrary.org/obo/ENVO_01000254 #environmental system
+subClassOf http://purl.obolibrary.org/obo/BFO_0000040 #material entity
 
 [Source term retrieval setting]
 includeNoIntermediates

--- a/src/ontology/OntoFox-input/input_ENVO.txt
+++ b/src/ontology/OntoFox-input/input_ENVO.txt
@@ -105,14 +105,11 @@ http://purl.obolibrary.org/obo/ENVO_01000600 #rainwater
 http://purl.obolibrary.org/obo/ENVO_01000825 #eaves
 http://purl.obolibrary.org/obo/ENVO_01000739 #habitat
 http://purl.obolibrary.org/obo/ENVO_01000773 #village
+http://purl.obolibrary.org/obo/ENVO_00000856 #city
 
 [Top level source term URIs and target direct superclass URIs]
 http://purl.obolibrary.org/obo/ENVO_01001260 #waste disposal process
 subClassOf http://purl.obolibrary.org/obo/OBI_0000011 #planned process
-http://purl.obolibrary.org/obo/ENVO_01000813 #astronomical body part
-subClassOf http://purl.obolibrary.org/obo/BFO_0000040 #material entity
-http://purl.obolibrary.org/obo/ENVO_00010483 #environmental material
-subClassOf http://purl.obolibrary.org/obo/BFO_0000040 #material entity
 http://purl.obolibrary.org/obo/ENVO_00001999 #marine water body
 subClassOf http://purl.obolibrary.org/obo/ENVO_01000617 #lentic water body
 http://purl.obolibrary.org/obo/ENVO_00003074 #manufactured product
@@ -147,7 +144,6 @@ http://purl.obolibrary.org/obo/IAO_0000115
 ENVO
 
 [Low level source term URIs]
-http://purl.obolibrary.org/obo/ENVO_00000856 #city
 http://purl.obolibrary.org/obo/ENVO_00005801 #rhizosphere
 http://purl.obolibrary.org/obo/ENVO_01000574 #candle
 http://purl.obolibrary.org/obo/ENVO_01000572 #electric lamp
@@ -172,12 +168,6 @@ http://purl.obolibrary.org/obo/ENVO_01000597 #pressure lamp
 subClassOf http://purl.obolibrary.org/obo/OBI_0400065 #light source
 http://purl.obolibrary.org/obo/ENVO_01000573 #battery-powered electric lamp
 subClassOf http://purl.obolibrary.org/obo/ENVO_01000572 #electric lamp
-http://purl.obolibrary.org/obo/ENVO_01000254 #environmental system
-subClassOf http://purl.obolibrary.org/obo/BFO_0000040 #material entity
-http://purl.obolibrary.org/obo/ENVO_00000856 #city
-subClassOf http://purl.obolibrary.org/obo/GAZ_00000448 #geographic location
-http://purl.obolibrary.org/obo/ENVO_00000004 #administrative region
-subClassOf http://purl.obolibrary.org/obo/GAZ_00000448 #geographic location
 http://purl.obolibrary.org/obo/ENVO_01000744 #human dwelling
 subClassOf http://purl.obolibrary.org/obo/ENVO_00000070 #human construction
 http://purl.obolibrary.org/obo/ENVO_00000182 #plateau

--- a/src/ontology/eupath_dev.owl
+++ b/src/ontology/eupath_dev.owl
@@ -5209,7 +5209,7 @@ value: the value of a multifilter</obo:IAO_0000115>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000006"/>
         <obo:IAO_0000115>A second-order administrative region of India.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Person: John Judkins</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">EuPathDB</obo:IAO_0000119>
+        <obo:IAO_0000119 xml:lang="en">VEuPathDB</obo:IAO_0000119>
         <rdfs:label>district of India</rdfs:label>
     </owl:Class>
     

--- a/src/ontology/eupath_dev.owl
+++ b/src/ontology/eupath_dev.owl
@@ -1792,18 +1792,18 @@ value: the value of a multifilter</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/EUPATH_0000054 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000054">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000448"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000008"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
                 <owl:hasValue rdf:resource="http://purl.obolibrary.org/obo/GAZ_00001102"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:IAO_0000115>A geographical location which is part of Uganda.</obo:IAO_0000115>
+        <obo:IAO_0000115>A fourth-order administrative region of Uganda.</obo:IAO_0000115>
         <obo:IAO_0000117>Person:  Jie Zheng, Chris Stoeckert</obo:IAO_0000117>
-        <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
         <dc:source>PRISM</dc:source>
-        <rdfs:label>subcounty in Uganda</rdfs:label>
+        <rdfs:label>subcounty of Uganda</rdfs:label>
     </owl:Class>
     
 
@@ -5206,11 +5206,11 @@ value: the value of a multifilter</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/EUPATH_0000407 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000407">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000300"/>
-        <obo:IAO_0000115 xml:lang="en">a textual entity that denotes a political entity that is a division of a state or territory of India</obo:IAO_0000115>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000006"/>
+        <obo:IAO_0000115>A second-order administrative region of India.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Person: John Judkins</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">EuPathDB</obo:IAO_0000119>
-        <rdfs:label xml:lang="en">district of India name</rdfs:label>
+        <rdfs:label>district of India</rdfs:label>
     </owl:Class>
     
 
@@ -5649,9 +5649,11 @@ value: the value of a multifilter</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/EUPATH_0000444 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000444">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000300"/>
-        <obo:IAO_0000115>A text entity denotes to a taluk.</obo:IAO_0000115>
-        <rdfs:label>taluk name</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000007"/>
+        <obo:IAO_0000115>A third-order administrative region of India.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <rdfs:label>taluk of India</rdfs:label>
     </owl:Class>
     
 
@@ -5729,9 +5731,11 @@ value: the value of a multifilter</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/EUPATH_0000452 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000452">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000300"/>
-        <obo:IAO_0000115>A text entity denotes to a village.</obo:IAO_0000115>
-        <rdfs:label>village name</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000005"/>
+        <obo:IAO_0000115>A first-order administrative region of Mali.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <rdfs:label>region of Mali</rdfs:label>
     </owl:Class>
     
 
@@ -13289,6 +13293,18 @@ CD3T188G is a polymophism on the human CD36 gene.</obo:IAO_0000116>
     
 
 
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0021095 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0021095">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000005"/>
+        <obo:IAO_0000115>A first-order administrative region of India.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <rdfs:label>state of India</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/EUPATH_0021096 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0021096">
@@ -14555,6 +14571,66 @@ CD3T188G is a polymophism on the human CD36 gene.</obo:IAO_0000116>
     
 
 
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0026002 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0026002">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000007"/>
+        <obo:IAO_0000115>A third-order administrative region of Thailand.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <rdfs:label>subdistrict of Thailand</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0026006 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0026006">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000006"/>
+        <obo:IAO_0000115>A second-order administrative region of Thailand.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <rdfs:label>district of Thailand</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0026007 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0026007">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000005"/>
+        <obo:IAO_0000115>A first-order administrative region of Thailand.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <rdfs:label>province of Thailand</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0028020 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0028020">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000004"/>
+        <obo:IAO_0000115>A fifth-order administrative region of Uganda.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <rdfs:label>parish of Uganda</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0035013 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0035013">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000008"/>
+        <obo:IAO_0000115>A fourth-order administrative region of Bangladesh.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <rdfs:label>union council of Bangladesh</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/EUPATH_0035127 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0035127">
@@ -14562,6 +14638,43 @@ CD3T188G is a polymophism on the human CD36 gene.</obo:IAO_0000116>
         <obo:IAO_0000115>An information content entity about the multiple households that share a location and a common trait such as infrastructure.</obo:IAO_0000115>
         <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
         <rdfs:label>community information</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0038721 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0038721">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000006"/>
+        <obo:IAO_0000115>A second-order administrative region of Ethiopia.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <rdfs:label>zone of Ethiopia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0038722 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0038722">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000008"/>
+        <obo:IAO_0000115>A fourth-order administrative region of Ethiopia.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000118>subdistrict of Ethiopia</obo:IAO_0000118>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <rdfs:label>kebele of Ethiopia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0038723 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0038723">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000007"/>
+        <obo:IAO_0000115>A third-order administrative region of Tanzania.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <rdfs:label>woreda of Ethiopia</rdfs:label>
     </owl:Class>
     
 
@@ -15756,6 +15869,42 @@ CD3T188G is a polymophism on the human CD36 gene.</obo:IAO_0000116>
         <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
         <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
         <rdfs:label>fed female insect status</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0044179 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0044179">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000006"/>
+        <obo:IAO_0000115>A second-order administrative region of Tanzania.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <rdfs:label>district of Uganda</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0044180 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0044180">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000005"/>
+        <obo:IAO_0000115>A first-order administrative region of Uganda.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <rdfs:label>region of Uganda</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0049405 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0049405">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000008"/>
+        <obo:IAO_0000115>A fourth-order administrative region of Tanzania.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <rdfs:label>ward of Tanzania</rdfs:label>
     </owl:Class>
     
 

--- a/src/ontology/eupath_dev.owl
+++ b/src/ontology/eupath_dev.owl
@@ -14671,7 +14671,7 @@ CD3T188G is a polymophism on the human CD36 gene.</obo:IAO_0000116>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0038723">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000007"/>
-        <obo:IAO_0000115>A third-order administrative region of Tanzania.</obo:IAO_0000115>
+        <obo:IAO_0000115>A third-order administrative region of Ethiopia.</obo:IAO_0000115>
         <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
         <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
         <rdfs:label>woreda of Ethiopia</rdfs:label>
@@ -15877,7 +15877,7 @@ CD3T188G is a polymophism on the human CD36 gene.</obo:IAO_0000116>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0044179">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000006"/>
-        <obo:IAO_0000115>A second-order administrative region of Tanzania.</obo:IAO_0000115>
+        <obo:IAO_0000115>A second-order administrative region of Uganda.</obo:IAO_0000115>
         <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
         <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
         <rdfs:label>district of Uganda</rdfs:label>

--- a/src/ontology/imports/import_ENVO.owl
+++ b/src/ontology/imports/import_ENVO.owl
@@ -45,9 +45,9 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/BFO_0000004 -->
+    <!-- http://purl.obolibrary.org/obo/BFO_0000029 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000004"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000029"/>
     
 
 
@@ -60,9 +60,65 @@
     <!-- http://purl.obolibrary.org/obo/ENVO_00000004 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_00000004">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000029"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000448"/>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">administrative region</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_00000005 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_00000005">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000004"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A primary administrative division of a country, such as a state in the United States.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">first-order administrative region</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_00000006 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_00000006">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000004"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A subdivision of a first-order administrative division.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">second-order administrative region</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_00000007 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_00000007">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000004"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A subdivision of a second-order administrative division.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">third-order administrative region</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_00000008 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_00000008">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000004"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A subdivision of a third-order administrative division.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fourth-order administrative region</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_00000009 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_00000009">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000004"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A political association with effective dominion over a geographic area.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">national geopolitical entity</rdfs:label>
     </owl:Class>
     
 
@@ -379,7 +435,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_00000486">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_01000813"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The line of contact between a body of water and the land.</obo:IAO_0000115>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A two-dimensional continuant fiat boundary which is located between a landmass and a water body.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shoreline</rdfs:label>
     </owl:Class>
@@ -868,7 +924,7 @@
     <!-- http://purl.obolibrary.org/obo/ENVO_01000408 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000408">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000029"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A site which has its extent determined by the presence or influence of one or more components of an environmental system or the processes occurring therein.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
         <rdfs:label>environmental zone</rdfs:label>

--- a/src/ontology/imports/import_ENVO.owl
+++ b/src/ontology/imports/import_ENVO.owl
@@ -45,6 +45,12 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/BFO_0000024 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000024"/>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/BFO_0000029 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000029"/>
@@ -61,7 +67,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_00000004">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000029"/>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000448"/>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">administrative region</rdfs:label>
     </owl:Class>
@@ -251,6 +256,17 @@
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A pond or lake used for the artificial culture of fish.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fishpond</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/ENVO_00000062 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_00000062">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_01000408"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Place or area with clustered or scattered buildings and a permanent human population.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">populated place</rdfs:label>
     </owl:Class>
     
 
@@ -457,7 +473,7 @@
     <!-- http://purl.obolibrary.org/obo/ENVO_00000856 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_00000856">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GAZ_00000448"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000062"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Incorporated populated place.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">city</rdfs:label>
@@ -804,7 +820,7 @@
     <!-- http://purl.obolibrary.org/obo/ENVO_00010483 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_00010483">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000024"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A portion of environmental material is a fiat object part which forms the medium or part of the medium of an environmental system.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">environmental material</rdfs:label>
@@ -901,12 +917,7 @@
 
     <!-- http://purl.obolibrary.org/obo/ENVO_01000254 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000254">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A system which has the disposition to environ one or more material entities.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">environmental system</rdfs:label>
-    </owl:Class>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000254"/>
     
 
 
@@ -1487,7 +1498,7 @@
     <!-- http://purl.obolibrary.org/obo/ENVO_01000773 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000773">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_01000408"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/ENVO_00000062"/>
         <obo:IAO_0000115>A village is a clustered human settlement or community, larger than a hamlet but smaller than a town, with a population ranging from a few hundred to a few thousand. Though often located in rural areas, the term urban village is also applied to certain urban neighbourhoods. Villages are normally permanent, with fixed dwellings; however, transient villages can occur. Further, the dwellings of a village are fairly close to one another, not scattered broadly over the landscape, as a dispersed settlement.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
         <rdfs:label xml:lang="en">village</rdfs:label>
@@ -1498,7 +1509,7 @@
     <!-- http://purl.obolibrary.org/obo/ENVO_01000813 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000813">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000024"/>
         <obo:IAO_0000115>A material part of an astronomical body.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
         <rdfs:label xml:lang="en">astronomical body part</rdfs:label>
@@ -1626,12 +1637,6 @@
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">excreta material</rdfs:label>
     </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/GAZ_00000448 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GAZ_00000448"/>
     
 
 

--- a/src/ontology/imports/import_ENVO.owl
+++ b/src/ontology/imports/import_ENVO.owl
@@ -917,7 +917,12 @@
 
     <!-- http://purl.obolibrary.org/obo/ENVO_01000254 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000254"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/ENVO_01000254">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A system which has the disposition to environ one or more material entities.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/envo.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">environmental system</rdfs:label>
+    </owl:Class>
     
 
 


### PR DESCRIPTION
Closes #243. This adds the new administrative region terms and restores part of the ENVO import hiearchy to match ENVO, i.e.
'site' > 'administrative region'
instead of
'site' > 'geographic location' > 'administrative region'.