### PR TITLE
add virus terms from NCBITaxon, NCIT

### DIFF
--- a/src/ontology/OntoFox-input/input_NCBITaxon.txt
+++ b/src/ontology/OntoFox-input/input_NCBITaxon.txt
@@ -80,7 +80,10 @@ http://purl.obolibrary.org/obo/NCBITaxon_1206015 #Psorophora signipennis
 http://purl.obolibrary.org/obo/NCBITaxon_1206282 #Culiseta particeps
 http://purl.obolibrary.org/obo/NCBITaxon_1206287 #Psorophora discolor
 http://purl.obolibrary.org/obo/NCBITaxon_1206303 #Ochlerotatus mitchellae
+http://purl.obolibrary.org/obo/NCBITaxon_12080 #Human poliovirus 1
 http://purl.obolibrary.org/obo/NCBITaxon_12082 #Human poliovirus 1 strain Sabin
+http://purl.obolibrary.org/obo/NCBITaxon_12083 #Human poliovirus 2
+http://purl.obolibrary.org/obo/NCBITaxon_12086 #Human poliovirus 3
 http://purl.obolibrary.org/obo/NCBITaxon_120868 #Anopheles claviger
 http://purl.obolibrary.org/obo/NCBITaxon_120869 #Ochlerotatus cantans
 http://purl.obolibrary.org/obo/NCBITaxon_120870 #Ochlerotatus caspius
@@ -275,6 +278,7 @@ http://purl.obolibrary.org/obo/NCBITaxon_24 #Shewanella putrifaciens
 http://purl.obolibrary.org/obo/NCBITaxon_251639 #Anopheles pullus
 http://purl.obolibrary.org/obo/NCBITaxon_253 #Chryseobacterium indologenes
 http://purl.obolibrary.org/obo/NCBITaxon_2560525 #Human orthorubulavirus 2
+http://purl.obolibrary.org/obo/NCBITaxon_2560526 #Human orthorubulavirus 4
 http://purl.obolibrary.org/obo/NCBITaxon_2563468 #Culex aurantepex
 http://purl.obolibrary.org/obo/NCBITaxon_2563597 #Mimomyia mimomyiaformis
 http://purl.obolibrary.org/obo/NCBITaxon_2563599 #Mimomyia mediolineata
@@ -289,8 +293,10 @@ http://purl.obolibrary.org/obo/NCBITaxon_266367 #Anthochaera chrysoptera
 http://purl.obolibrary.org/obo/NCBITaxon_266418 #Phylidonyris novaehollandiae
 http://purl.obolibrary.org/obo/NCBITaxon_2665964 #Cryptococcus neoformans var. grubii VNI
 http://purl.obolibrary.org/obo/NCBITaxon_269190 #Platycercus elegans (Crimson/Adelaide rosella)
+http://purl.obolibrary.org/obo/NCBITaxon_2697049 #Severe acute respiratory syndrome coronavirus 2
 http://purl.obolibrary.org/obo/NCBITaxon_270338 #Human poliovirus 3 strain Sabin
 http://purl.obolibrary.org/obo/NCBITaxon_273454 #Anopheles sergentii
+http://purl.obolibrary.org/obo/NCBITaxon_2751882 #Rotavirus A P4
 http://purl.obolibrary.org/obo/NCBITaxon_2759 #Eukaryota
 http://purl.obolibrary.org/obo/NCBITaxon_2761511 #Aedes ledgeri
 http://purl.obolibrary.org/obo/NCBITaxon_277944 #Human coronavirus NL63
@@ -529,6 +535,7 @@ http://purl.obolibrary.org/obo/NCBITaxon_561 #Escherichia
 http://purl.obolibrary.org/obo/NCBITaxon_561267 #Culex theileri
 http://purl.obolibrary.org/obo/NCBITaxon_562 #Escherichia coli
 http://purl.obolibrary.org/obo/NCBITaxon_562834 #Culex nebulosus
+http://purl.obolibrary.org/obo/NCBITaxon_566029 #Human rotavirus P6
 http://purl.obolibrary.org/obo/NCBITaxon_56625 #Isospora
 http://purl.obolibrary.org/obo/NCBITaxon_569587 #Aedes alternans
 http://purl.obolibrary.org/obo/NCBITaxon_571 #Klebsiella oxytoca
@@ -635,6 +642,7 @@ http://purl.obolibrary.org/obo/NCBITaxon_702 #Plesiomonas
 http://purl.obolibrary.org/obo/NCBITaxon_703 #Plesiomonas shigelloides
 http://purl.obolibrary.org/obo/NCBITaxon_70327 #Anopheles rivulorum
 http://purl.obolibrary.org/obo/NCBITaxon_704160 #Culiseta inornata
+http://purl.obolibrary.org/obo/NCBITaxon_71031 #Rotavirus G8
 http://purl.obolibrary.org/obo/NCBITaxon_7149 #Chironomidae
 http://purl.obolibrary.org/obo/NCBITaxon_7157 #Culicidae
 http://purl.obolibrary.org/obo/NCBITaxon_7158 #Aedes <genus>
@@ -667,7 +675,8 @@ http://purl.obolibrary.org/obo/NCBITaxon_724 #Haemophilus
 http://purl.obolibrary.org/obo/NCBITaxon_72408 #Anopheles sacharovi
 http://purl.obolibrary.org/obo/NCBITaxon_726 #Haemophilus haemolyticus
 http://purl.obolibrary.org/obo/NCBITaxon_727 #Haemophilus influenzae
-http://purl.obolibrary.org/obo/NCBITaxon_729 #Haemophilus parainfluenzae 
+http://purl.obolibrary.org/obo/NCBITaxon_729 #Haemophilus parainfluenzae
+http://purl.obolibrary.org/obo/NCBITaxon_73036 #Rotavirus G3
 http://purl.obolibrary.org/obo/NCBITaxon_732 #Agregattibacter aphrophilus (Haemophilus aphrophilus)
 http://purl.obolibrary.org/obo/NCBITaxon_735 #Haemophilus parahaemolyticus 
 http://purl.obolibrary.org/obo/NCBITaxon_743691 #Ochlerotatus fitchii

--- a/src/ontology/OntoFox-input/input_NCIT.txt
+++ b/src/ontology/OntoFox-input/input_NCIT.txt
@@ -53,6 +53,8 @@ http://purl.obolibrary.org/obo/NCIT_C106273 #ABO Hemolytic Disease of the Newbor
 subClassOf http://purl.obolibrary.org/obo/DOID_2355 #anemia
 http://purl.obolibrary.org/obo/NCIT_C62584 #Coagulase-Negative Staphylococcus
 subClassOf http://purl.obolibrary.org/obo/NCBITaxon_1279 #Staphylococcus
+http://purl.obolibrary.org/obo/NCIT_C77200 #Rhinovirus
+subClassOf http://purl.obolibrary.org/obo/NCBITaxon_12059 #Enterovirus
 
 [Source term retrieval setting]
 includeNoIntermediates

--- a/src/ontology/imports/import_NCBITaxon.owl
+++ b/src/ontology/imports/import_NCBITaxon.owl
@@ -919,12 +919,42 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_12080 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12080">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_138950"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human poliovirus 1</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_12082 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12082">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_138950"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_12080"/>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human poliovirus 1 strain Sabin</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_12083 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12083">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_138950"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human poliovirus 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_12086 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12086">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_138950"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human poliovirus 3</rdfs:label>
     </owl:Class>
     
 
@@ -3139,12 +3169,32 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_2560195 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2560195">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11158"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Orthorubulavirus</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_2560525 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2560525">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11158"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2560195"/>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human orthorubulavirus 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_2560526 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2560526">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2560195"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human orthorubulavirus 4</rdfs:label>
     </owl:Class>
     
 
@@ -3319,6 +3369,16 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_2697049 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2697049">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_694002"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Severe acute respiratory syndrome coronavirus 2</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_2698737 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2698737">
@@ -3332,7 +3392,7 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_270338 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_270338">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_138950"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_12086"/>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human poliovirus 3 strain Sabin</rdfs:label>
     </owl:Class>
@@ -3395,6 +3455,16 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_59140"/>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anopheles sergentii</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_2751882 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2751882">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_28875"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rotavirus A P4</rdfs:label>
     </owl:Class>
     
 
@@ -6529,6 +6599,16 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_566029 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_566029">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_28875"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human rotavirus P6</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_56625 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_56625">
@@ -7819,6 +7899,16 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_71031 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_71031">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_28875"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rotavirus G8</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_712 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_712">
@@ -8175,6 +8265,16 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_724"/>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Haemophilus parainfluenzae</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_73036 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_73036">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_28875"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rotavirus G3</rdfs:label>
     </owl:Class>
     
 
@@ -9242,7 +9342,7 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_990147 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_990147">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_138950"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_12083"/>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human poliovirus 2 strain Sabin</rdfs:label>
     </owl:Class>

--- a/src/ontology/imports/import_NCIT.owl
+++ b/src/ontology/imports/import_NCIT.owl
@@ -87,6 +87,12 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_12059 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12059"/>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_1279 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1279"/>
@@ -243,6 +249,17 @@
         <obo:IAO_0000115>A period of three months; especially one of the three three-month periods into which human pregnancy is divided.</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
         <rdfs:label>Trimester</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCIT_C77200 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCIT_C77200">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_12059"/>
+        <obo:IAO_0000115>A genus of single-stranded positive sense RNA viruses containing a single RNA molecule. The viral particles are not enveloped and are icosahedral in structure.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
+        <rdfs:label>Rhinovirus</rdfs:label>
     </owl:Class>
     
 


### PR DESCRIPTION
These viruses are mentioned in ClinEpi projects and are needed for the raw_data template. Rhinovirus is from NCIT because NCBITaxon only has Rhinovirus A, B, and C separately.