### PR TITLE
fixed minor issues after running make

### DIFF
--- a/src/ontology/eupath_dev.owl
+++ b/src/ontology/eupath_dev.owl
@@ -14,6 +14,7 @@
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/eupath_dev.owl">
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/bfo.owl"/>
+        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/omo.owl"/>
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/eupath/dev/assays.owl"/>
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/eupath/dev/chebi_roles.owl"/>
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/eupath/dev/clinical-chemistry-data.owl"/>
@@ -77,7 +78,6 @@
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/eupath/dev/schedule_deprecate.owl"/>
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/eupath/dev/symptom_duration.owl"/>
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/eupath/dev/threshold-cycle.owl"/>
-        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/omo.owl"/>
         <dc:creator>Chris Stoeckert</dc:creator>
         <dc:creator>Cristian Cocos</dc:creator>
         <dc:creator>Jie Zheng</dc:creator>
@@ -13755,6 +13755,18 @@ CD3T188G is a polymophism on the human CD36 gene.</obo:IAO_0000116>
         <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
         <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
         <rdfs:label>region of Uganda</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0048259 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0048259">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0003239"/>
+        <obo:IAO_0000115>A saliva assay that evaulates a specimen collected from the biological mother of an infant.</obo:IAO_0000115>
+        <obo:IAO_0000117>John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <rdfs:label>maternal saliva assay</rdfs:label>
     </owl:Class>
     
 

--- a/src/ontology/eupath_dev.owl
+++ b/src/ontology/eupath_dev.owl
@@ -2030,6 +2030,19 @@ value: the value of a multifilter</obo:IAO_0000115>
     
 
 
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0000128 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000128">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000953"/>
+        <obo:IAO_0000115>A processed specimen that is extracted from whole blood using gradient centrifugation that separates the blood into a layer of peripheral blood mononuclear cell under the top layer of plasma. It contains lymphocytes, monocytes or macrophages that are critical components in the immune system.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person:  Jie Zheng, Chris Stoeckert</obo:IAO_0000117>
+        <obo:IAO_0000118>PBMC specimen</obo:IAO_0000118>
+        <obo:IAO_0000119>http://en.wikipedia.org/wiki/Peripheral_blood_mononuclear_cell</obo:IAO_0000119>
+        <rdfs:label>peripheral blood mononuclear cell specimen</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/EUPATH_0000129 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000129"/>


### PR DESCRIPTION
I ran `make`, and it found 2 dropped IRIs.
So I restored the IRI previously labeled as 'saliva test' (mentioned in #318), relabeling it as 'maternal saliva assay' and giving it the definition approved by Outreach.
I also restored the PBMC specimen term (I submitted the term to OBI).
This PR includes those changes and the eupath.owl file for the release candidate.