### PR TITLE
column headers for new term lists

### DIFF
--- a/new-imports.tsv
+++ b/new-imports.tsv
@@ -1,3 +1,4 @@
+"ID"	"Label"
 "GO:0001967"	"suckling behavior"
 "IAO:0000118"	"alternative term"
 "IAO:0020010"	"identifier creating process"

--- a/new-terms.tsv
+++ b/new-terms.tsv
@@ -1,3 +1,4 @@
+"ID"	"Label"
 "EUPATH:0005032"	"parasitized erythrocyte count to total erythrocyte count ratio"
 "EUPATH:0043247"	"Anopheles nuneztovari sensu lato"
 "EUPATH:0043254"	"Anaplasma phagocytophilum str. Ap-ha"


### PR DESCRIPTION
This gives column headers to new-terms.tsv and new-imports.tsv to make them look better. I'll link to these in the release notes.